### PR TITLE
Improvements to Async Entry screen

### DIFF
--- a/src/components/BottomActionBar.svelte
+++ b/src/components/BottomActionBar.svelte
@@ -18,6 +18,7 @@
   @import "src/styles/tokens";
   .bar {
     position: fixed;
+    z-index: 10;
     left: 0;
     bottom: 0;
     height: $action-bar-height;

--- a/src/routes/AsyncEntryEditor.svelte
+++ b/src/routes/AsyncEntryEditor.svelte
@@ -9,6 +9,7 @@
   import ContentFrame from "../components/layout/ContentFrame.svelte";
   import RichLabel from "../components/RichLabel.svelte";
   import SegmentedSelector from "../components/SegmentedSelector.svelte";
+  import CONFIG from "../data/config";
   import type { AsyncEntry, AsyncProject, DesignModel } from "../data/schema";
   import { fromDate, MONTH_NAME } from "../util/date";
 
@@ -50,10 +51,17 @@
     total = roundD2(values.reduce((a, b) => a + b, 0));
   }
 
+  let suppressBeforeUnload = false;
+  (async function () {
+    suppressBeforeUnload = await CONFIG.getDevSuppressBeforeUnload();
+  })();
+
   function beforeUnload(evt: BeforeUnloadEvent) {
-    evt.preventDefault();
-    evt.returnValue = "Changes may not be saved.";
-    return "Changes may not be saved.";
+    if (!suppressBeforeUnload) {
+      evt.preventDefault();
+      evt.returnValue = "Changes may not be saved.";
+      return "Changes may not be saved.";
+    }
   }
 
   const update = (i: number) => () => {

--- a/src/routes/AsyncEntryEditor.svelte
+++ b/src/routes/AsyncEntryEditor.svelte
@@ -21,8 +21,6 @@
   export let save: () => Promise<void>;
   export let designModel: DesignModel;
 
-  let alertScrollAnchor: HTMLDivElement;
-
   const TOTAL_PERCENT_FUDGE_ALLOW = 1;
 
   if (!label) {
@@ -107,7 +105,7 @@
       calculateTotalPercentage();
       if (total === 0 && totalPercentage !== 0) {
         totalPercentageOK = false;
-        alertScrollAnchor?.scrollIntoView?.();
+        document.documentElement.scrollTo({ top: 0, behavior: "smooth" });
         return;
       }
     }
@@ -130,7 +128,6 @@
     />
   </RichLabel>
 
-  <div bind:this={alertScrollAnchor} role="presentation" />
   <ActivityEntrySlat
     activity={designModel.activities[0]}
     bind:value={total}
@@ -144,7 +141,9 @@
   {#if entryMode === "percent" && !totalPercentageOK && !total}
     <div class="alert-area">
       <Alert type="note" icon={totalAlertIcon}>
-        If you want to create an empty entry, set all activity percentages to 0.
+        If you want to create an empty entry, <strong>
+          set all activity percentages to 0.
+        </strong>
       </Alert>
     </div>
   {/if}
@@ -200,7 +199,7 @@
     @include type-style($type-section-header);
     text-align: center;
     padding: 0.5rem;
-    z-index: 1;
+    z-index: 10;
   }
   .spacer {
     height: 1rem + rem(map-get($type-section-header, height));


### PR DESCRIPTION
This PR contains the following improvements
* Reload check on Async Entry screen is skipped if suppressed through developer settings
* Alert is shown if percent total ≠ 100±1
* Save is disabled if percent total ≠ 100±1

This PR is waiting on:
- [x] UX review of alert copy