### PR TITLE
fix: restore right alignment of reflect button

### DIFF
--- a/src/routes/ProjectDetailAsync.svelte
+++ b/src/routes/ProjectDetailAsync.svelte
@@ -172,6 +172,12 @@
     justify-content: space-between;
   }
 
+  .reflect-button {
+    margin-top: $block-vertical-spacing;
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .contextual-notes {
     margin-top: $block-vertical-spacing;
   }

--- a/src/routes/ProjectDetailRealtime.svelte
+++ b/src/routes/ProjectDetailRealtime.svelte
@@ -142,6 +142,12 @@
     justify-content: space-between;
   }
 
+  .reflect-button {
+    margin-top: $block-vertical-spacing;
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .note-meta {
     white-space: nowrap;
     padding-right: 0.5rem;


### PR DESCRIPTION
During refactoring in 1c56417c49a3289affbc02c1a1d8dea71be39549, styles right-aligning the reflect button on project detail pages were removed. This change restores the correct alignment.