### PR TITLE
Add entry metadata & persist display/entry unit selection

### DIFF
--- a/src/components/ProjectSummary.svelte
+++ b/src/components/ProjectSummary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { DesignModel } from "../data/schema";
+  import type { AsyncProject, RealtimeProject } from "../data/schema";
   import { expressiveDurationM } from "../util/time";
   import type { Bar } from "./BarChart.svelte";
   import BarGraph from "./BarChart.svelte";
@@ -7,25 +7,27 @@
   import SegmentedSelector from "./SegmentedSelector.svelte";
   import Header from "./type/Header.svelte";
 
-  export let designModel: DesignModel;
+  export let project: AsyncProject | RealtimeProject;
   export let chartData: number[];
   export let count: number;
   export let countLabel: string;
   export let firstLast: [string, string];
   export let firstLastType: string;
 
-  let chartMode: "raw" | "percent" = "raw";
+  // cast isn't always correct, but this lets us use getMeta
+  let chartMode = (project as AsyncProject).getMeta("barViewUnit", "raw");
 
   let bars: Bar[];
   let total: number;
   $: {
+    (project as AsyncProject).setMeta("barViewUnit", chartMode);
     if (chartMode === "percent") {
       total = chartData.reduce((a, b) => a + b, 0);
     }
     bars = chartData.map((value, i) => ({
       value,
-      color: designModel.activities[i].color,
-      label: designModel.activities[i].code,
+      color: project.designModel.activities[i].color,
+      label: project.designModel.activities[i].code,
       valueStr:
         chartMode === "raw"
           ? expressiveDurationM(value)

--- a/src/components/ProjectSummaryAsync.svelte
+++ b/src/components/ProjectSummaryAsync.svelte
@@ -48,7 +48,7 @@
 </script>
 
 <ProjectSummary
-  designModel={project.designModel}
+  {project}
   chartData={activityTotals}
   count={project.entries.length}
   countLabel="Total entries"

--- a/src/components/ProjectSummaryRealtime.svelte
+++ b/src/components/ProjectSummaryRealtime.svelte
@@ -46,7 +46,7 @@
 </script>
 
 <ProjectSummary
-  designModel={project.designModel}
+  {project}
   chartData={activityTotals}
   count={project.sessions.length}
   countLabel="Total sessions"

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -4,6 +4,7 @@ import * as Schema from "./schema";
 import { initializeConfiguration, upgradeDatabase } from "./upgradeDatabase";
 
 const DB_NAME = "design-awareness-local-store";
+const META_KEY = "@meta";
 const DEBUG_DELAY = 0;
 
 type DBID = string;
@@ -319,6 +320,7 @@ function createClientObject(
   const schema = Schema.Schema[store];
   const data: Record<string, any> = {};
   const obj = {};
+  let meta: Record<string, any> = {};
   const childResolvers = [];
 
   // client obj private properties
@@ -374,6 +376,9 @@ function createClientObject(
         }
       },
     });
+  }
+  if (typeof rawObj[META_KEY] === "object") {
+    meta = rawObj[META_KEY];
   }
 
   // add wrapper properties & methods
@@ -434,6 +439,7 @@ function createClientObject(
             }
           }
         }
+        dbObj[META_KEY] = meta;
 
         dirty = false;
 
@@ -493,6 +499,16 @@ function createClientObject(
           encoder: "design-awareness-app@" + VERSION,
         },
       });
+    },
+
+    getMeta(key: string, defaultValue: any) {
+      return meta[key] ?? defaultValue;
+    },
+    setMeta(key: string, value: any) {
+      if (meta[key] !== value) {
+        meta[key] = value;
+        dirty = true;
+      }
     },
   });
 

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -12,7 +12,9 @@ import type {
 /**
  * Base methods available on database entity objects
  */
-export interface Entity extends DataType.Entity {
+export interface Entity<
+  MetadataType extends Record<string, any> = Record<string, any>
+> extends DataType.Entity {
   readonly id: string;
   readonly dirty: boolean;
   readonly saving: boolean;
@@ -21,7 +23,14 @@ export interface Entity extends DataType.Entity {
   remove(): Promise<void>;
   toSerializable(): object;
   serialize(): string;
+  getMeta<K extends keyof MetadataType>(
+    key: K,
+    defaultValue: MetadataType[K]
+  ): MetadataType[K];
+  setMeta<K extends keyof MetadataType>(key: K, value: MetadataType[K]): void;
 }
+
+type EmptyMeta = Record<never, never>;
 
 // [key, model name, array?]
 // [key, null, default]
@@ -65,7 +74,9 @@ type Prepare<I> = Omit<DeepReadonly<DeepRequired<I>>, "id">;
 
 ///// INTERFACE DEFINITIONS
 
-export interface AsyncEntry extends Entity, Prepare<DataType.AsyncEntry> {}
+export interface AsyncEntry
+  extends Entity<EmptyMeta>,
+    Prepare<DataType.AsyncEntry> {}
 
 const AsyncEntrySchema = makeSchema<AsyncEntry>({
   created: [null, currentDate],
@@ -75,8 +86,15 @@ const AsyncEntrySchema = makeSchema<AsyncEntry>({
   period: [null, currentDate],
 });
 
+interface ProjectMeta {
+  barViewUnit: "raw" | "percent";
+}
+interface AsyncProjectMeta extends ProjectMeta {
+  entryUnit: "raw" | "percent";
+}
+
 export interface AsyncProject
-  extends Entity,
+  extends Entity<AsyncProjectMeta>,
     SetPropertyTypes<
       Prepare<DataType.AsyncProject>,
       [
@@ -99,7 +117,9 @@ const AsyncProjectSchema = makeSchema<AsyncProject>({
   reportingPeriod: [null, "day"],
 });
 
-export interface DesignModel extends Entity, Prepare<DataType.DesignModel> {}
+export interface DesignModel
+  extends Entity<EmptyMeta>,
+    Prepare<DataType.DesignModel> {}
 
 const DesignModelSchema = makeSchema<DesignModel>({
   activities: [null, emptyArr],
@@ -108,15 +128,19 @@ const DesignModelSchema = makeSchema<DesignModel>({
   wellKnown: [null, false],
 });
 
-export interface ProjectNote extends Entity, Prepare<DataType.ProjectNote> {}
+export interface ProjectNote
+  extends Entity<EmptyMeta>,
+    Prepare<DataType.ProjectNote> {}
 
 const ProjectNoteSchema = makeSchema<ProjectNote>({
   content: [null, ""],
   created: [null, currentDate],
 });
 
+interface RealtimeProjectMeta extends ProjectMeta {}
+
 export interface RealtimeProject
-  extends Entity,
+  extends Entity<RealtimeProjectMeta>,
     SetPropertyTypes<
       Prepare<DataType.RealtimeProject>,
       [
@@ -138,7 +162,7 @@ const RealtimeProjectSchema = makeSchema<RealtimeProject>({
 });
 
 export interface RealtimeSession
-  extends Entity,
+  extends Entity<EmptyMeta>,
     SetPropertyTypes<
       Prepare<DataType.RealtimeSession>,
       [["notes", TimedNote[]]]
@@ -151,7 +175,9 @@ const RealtimeSessionSchema = makeSchema<RealtimeSession>({
   start: [null, currentDate],
 });
 
-export interface TimedNote extends Entity, Prepare<DataType.TimedNote> {}
+export interface TimedNote
+  extends Entity<EmptyMeta>,
+    Prepare<DataType.TimedNote> {}
 
 const TimedNoteSchema = makeSchema<TimedNote>({
   content: [null, ""],

--- a/src/routes/AsyncEntryEditor.svelte
+++ b/src/routes/AsyncEntryEditor.svelte
@@ -5,9 +5,10 @@
   import ContentFrame from "../components/layout/ContentFrame.svelte";
   import RichLabel from "../components/RichLabel.svelte";
   import SegmentedSelector from "../components/SegmentedSelector.svelte";
-  import type { AsyncEntry, DesignModel } from "../data/schema";
+  import type { AsyncEntry, AsyncProject, DesignModel } from "../data/schema";
   import { fromDate, MONTH_NAME } from "../util/date";
 
+  export let project: AsyncProject;
   export let entry: AsyncEntry;
   export let label: string;
   export let save: () => Promise<void>;
@@ -22,12 +23,14 @@
   let notes = entry.data.map((data) => data.note);
 
   type EntryMode = "raw" | "percent";
-  let entryMode: EntryMode = "raw";
-  let lastEntryMode: EntryMode = entryMode;
+  let entryMode = project.getMeta("entryUnit", "raw");
+  let lastEntryMode: EntryMode = "raw";
   let total = 0;
   calculateTotal();
   $: if (lastEntryMode !== entryMode) {
     lastEntryMode = entryMode;
+    project.setMeta("entryUnit", entryMode);
+    project.save();
     if (entryMode === "percent") {
       values = values.map((value) => value && roundD2((value * 100) / total));
     } else {

--- a/src/routes/ProjectDetailAsync.svelte
+++ b/src/routes/ProjectDetailAsync.svelte
@@ -67,6 +67,7 @@
 <main class="device-frame page">
   {#if showEntry && activeEntry}
     <AsyncEntryEditor
+      {project}
       entry={activeEntry}
       label={entryLabel}
       save={saveEntry}


### PR DESCRIPTION
* This change adds new mechanisms (`getMeta()`, `setMeta()`) to store and retrieve persistent metadata on database entries. Metadata fields are strongly typechecked and can be edited in data/schema. Metadata is not exported as part of entry serialization.
* Bar chart display and entry units (percent/absolute) are now saved for each project using the new entity metadata mechanism. (#50)