### PR TITLE
fix: change atman extended model id

### DIFF
--- a/src/data/designModelPresets.ts
+++ b/src/data/designModelPresets.ts
@@ -114,7 +114,7 @@ export const presetDesignModels = [
     },
   ],
   [
-    "edu.washington.hcde.atman@0.1",
+    "edu.washington.hcde.atman_extended@0.1",
     {
       name: "Atman model (extended)",
       description: {

--- a/src/routes/Import.svelte
+++ b/src/routes/Import.svelte
@@ -362,7 +362,6 @@
             <Button small on:click={copyStack}>Copy to clipboard</Button>
           {/if}
         </div>
-        >
       {/if}
     {/if}
     {#if state === "reading"}


### PR DESCRIPTION
Oops! The atman extended model and atman model had the same id,
which is what was causing the "key already exists" error on first
launch, and also meant that if you used the extended one, you'd
actually get the non-extended one the next time you loaded that
project from the db. This was particularly bad if you used activities
9 or 10, which don't exist in the other one, and will crash your app
when it tries to render the timelines. (n.b.: this should also be
more resilient!)

This fix just changes the ID, but projects will still be broken.
If you need to keep a project that was affected, you'll probably need
to export it, swap out the design models manually, and load it back in.
God help you if you have many projects you want to keep.

This brings to mind that we might want to create some sort of "recovery"
mode where you end up if any uncaught errors occur, and we can let you
export, delete, and maybe repair possibly problematic projects or other
entities :^)