### PR TITLE
add "Import project" link to New Project page

### DIFF
--- a/src/components/Link.svelte
+++ b/src/components/Link.svelte
@@ -2,19 +2,9 @@
   Copyright (c) 2021, Design Awareness Contributors.
   SPDX-License-Identifier: BSD-3-Clause
 -->
-<script lang="ts">
+<script lang="ts" context="module">
   import { push, replace } from "svelte-spa-router/Router.svelte";
   import { goUpSafe } from "../util/history";
-
-  export let href: string;
-  export let up = false;
-  export let enforce = false;
-  export let horizontal = false;
-
-  function click(evt: MouseEvent) {
-    evt.preventDefault();
-    navigate({ href, up, enforce, horizontal });
-  }
 
   function navigate({
     href,
@@ -46,6 +36,18 @@
 
   export function goDown(href: string) {
     navigate({ href });
+  }
+</script>
+
+<script lang="ts">
+  export let href: string;
+  export let up = false;
+  export let enforce = false;
+  export let horizontal = false;
+
+  function click(evt: MouseEvent) {
+    evt.preventDefault();
+    navigate({ href, up, enforce, horizontal });
   }
 </script>
 

--- a/src/routes/NewProjectType.svelte
+++ b/src/routes/NewProjectType.svelte
@@ -7,6 +7,7 @@
   import BackButton from "../components/BackButton.svelte";
   import BottomActionBar from "../components/BottomActionBar.svelte";
   import ContentFrame from "../components/layout/ContentFrame.svelte";
+  import Link from "../components/Link.svelte";
   import SegmentedComponentSelector from "../components/SegmentedComponentSelector.svelte";
   import TrackingModeOption from "../components/TrackingModeOption.svelte";
   import Header from "../components/type/Header.svelte";
@@ -31,14 +32,23 @@
       ]}
       bind:value={option}
     />
+    <p>
+      <Link href="/import/" horizontal>Import a project from a file</Link>
+    </p>
     <BottomActionBar label="Next" disabled={!option} on:click={go} />
   </ContentFrame>
 </main>
 
 <style lang="scss">
   @import "src/styles/tokens";
+  @import "src/styles/type";
   .page {
     background-color: $background-color;
     min-height: 100%;
+  }
+
+  p {
+    text-align: center;
+    @include type-style($type-detail);
   }
 </style>


### PR DESCRIPTION
This change adds a link to import a project from the new project page accessible from the "New project" card on the home screen.